### PR TITLE
Add kubernetes config and job to transform xAOD file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,58 @@
 Event Data Streaming Service for ServiceX. This service accepts flattened
 N-tuples ans streams them out for analysis using Kafka.
 
+# Installation
+The Datastream Service runs inside a Kubernetes cluster.
+## Install Kafka 
+```bash
+$ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
+$ kubectl create ns kafka
+$ helm install --name my-kafka --namespace kafka incubator/kafka
+```
+
+## Create a namespace
+We will put all of our applicaton pods in the `servicex` namespace.
+
+```bash
+% kubectl create namespace servicex
+```
+
+## Set up a shared volume for Event Data
+Create a persistent volume claim called `servicex-pvc`. We create this with
+```bash
+% kubectl -n servicex create -f kube/pvc.yml
+```
+
+To make it easier to work with this persistent volume, we will create a busybox
+pod with the volume mounted.
+```bash
+% kubectl -n servicex create -f busybox.yml
+```
+
+When the pod is ready, you can create a shell with 
+```bash
+% kubectl exec -it -n servicex busybox sh
+```
+you can see the mount under `/servicex`
+
+You can copy a sample xAOD Root file into the shared volume using this pod with
+```bash
+% kubectl cp AOD.11182705._000001.pool.root.1 servicex/busybox:servicex/AOD.11182705._000001.pool.root.1
+```
+
+# Run the Transformer on the Data
+We use a containerized transformer from 
+[ServiceX_transformer](https://github.com/ssl-hep/ServiceX_transformer) to 
+read the xAOD File and reduce it to flattened n-tuples.
+
+```bash
+% kubectl -n servicex create -f transform_job.yml
+``` 
+
+When this job complets, there will be two files in the shared volume:
+- flat_file.root: Flattened n-tuple root file
+- xaodBranches.txt: Dump of all of the branch names from the original file
+ 
 # Acknowledgements
 
 This project is supported by National Science Foundation under Cooperative 

--- a/kube/busybox.yml
+++ b/kube/busybox.yml
@@ -1,0 +1,16 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: busybox
+spec:
+  volumes:
+    - name: servicex-storage
+      persistentVolumeClaim:
+       claimName: servicex-pvc
+  containers:
+    - name: task-pv-container
+      image: busybox
+      command: ['sleep', '3600']
+      volumeMounts:
+        - mountPath: "/servicex"
+          name: servicex-storage

--- a/kube/pvc.yml
+++ b/kube/pvc.yml
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: servicex-pvc
+  annotations:
+    volume.beta.kubernetes.io/storage-class: "nfs"
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 5Gi

--- a/kube/testclient.yml
+++ b/kube/testclient.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: testclient
+  namespace: kafka
+spec:
+  containers:
+  - name: kafka
+    image: solsson/kafka:0.11.0.0
+    command:
+      - sh
+      - -c
+      - "exec tail -f /dev/null"

--- a/kube/transform_job.yml
+++ b/kube/transform_job.yml
@@ -1,0 +1,35 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: servicex-transform
+spec:
+  backoffLimit: 6 # number of retries before throwing error
+  activeDeadlineSeconds: 360 # time to allow job to run
+  template:
+    metadata:
+      labels:
+        app: kubernetes-series
+        tier: job
+    spec:
+      restartPolicy: OnFailure
+      volumes:
+        - name: servicex-storage
+          persistentVolumeClaim:
+            claimName: servicex-pvc
+      containers:
+        - name: job
+          image: bengal1/servicex_transformer:standalone
+          volumeMounts:
+          - mountPath: "/data"
+            name: servicex-storage
+          # environment variables for the Pod
+          env:
+          - name: GCLOUD_PROJECT
+            value: PROJECT_NAME
+          - name: MESSAGE
+            value: I am a single run job
+          - name: FOREIGN_SERVICE
+            value: http://endpoints.default.svc.cluster.local/single
+          - name: NODE_ENV
+            value: production
+          args: ["-f", "/data/AOD.11182705._000001.pool.root.1"]


### PR DESCRIPTION
Fixes #1 
# Problem
Users need to be able to run a transformer job on the Kubernetes cluster.

# Approach
Documented in README how to deploy basic system in Kubernetes. Wrote kubernetes yaml files to 
set up a shared volume and then run a job that invokes the ServiceX_transform container to save flattened n-tuples to the share 